### PR TITLE
Encoding

### DIFF
--- a/src/raggen/core/build/build_service.py
+++ b/src/raggen/core/build/build_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pathlib
 from raggen.core.config.project import ProjectConfig
 from raggen.core.metadata.compare import changed_foundation_fields
 from raggen.core.metadata.models import ProjectLifecycleState
@@ -25,7 +26,7 @@ def do_build(
 
     cfg = ProjectConfig.get_config()
     root_p = cfg.project_root
-    cfg_path = root_p / config_path
+    cfg_path = pathlib.Path.joinpath(root_p, config_path)
 
     state_path = project_state_path(root_p)
 

--- a/src/raggen/core/chunking/chunker.py
+++ b/src/raggen/core/chunking/chunker.py
@@ -66,8 +66,13 @@ class ChunkerRegistry:
         Return a chunker for the given group.
         Unknown groups resolve to the configured fallback group.
         """
+        if group not in self.group_configs:
+            available = list(self.group_configs.keys())
+            raise ValueError(
+                f"No chunking config registered for group '{group}'. "
+                f"Available groups: {available}"
+            )
         chunk_config = self.group_configs[group]
-
         return self._build_chunker(chunk_config)
 
     def _build_chunker(self, conf: GroupChunkingConfig) -> BaseChunker:
@@ -127,7 +132,6 @@ def _enrich_chunks(
 
     This version does not rely on char offsets.
     """
-    # TODO:calculate cnfig_hash once per config
     config_hash = _stable_config_hash(conf)
     doc_id = getattr(doc, "doc_id", "unknown")
     source = getattr(doc, "source", None)

--- a/src/raggen/core/config/project.py
+++ b/src/raggen/core/config/project.py
@@ -11,6 +11,7 @@ import json
 class ScanConfig(TOMLDataclass):
     ignore_files: List[str] = field(default_factory=lambda: [".gitignore"])
     ignore: List[str] = field(default_factory=lambda: [".venv/", "node_modules/"])
+    max_encoding_error_ratio: float = 0.05
 
 
 @dataclass

--- a/src/raggen/core/ingest/gating.py
+++ b/src/raggen/core/ingest/gating.py
@@ -45,12 +45,11 @@ def should_ingest_changed_file(fr: FileRef, cfg: ProjectConfig) -> bool:
     Checks for duplicate in database (already ingested) by mtime & byte size.
     """
     engine = get_engine()
-    conn = engine.connect()
-    sel = select(documents.c.doc_id, documents.c.byte_size, documents.c.mtime_ns).where(
-        documents.c.doc_id == fr.relative_path
-    )
-    res = conn.execute(sel).fetchone()
-    conn.close()
+    with engine.connect() as conn:
+        sel = select(documents.c.doc_id, documents.c.byte_size, documents.c.mtime_ns).where(
+            documents.c.doc_id == fr.relative_path
+        )
+        res = conn.execute(sel).fetchone()
 
     if not res:
         # new file

--- a/src/raggen/core/ingest/ingest_service.py
+++ b/src/raggen/core/ingest/ingest_service.py
@@ -63,7 +63,8 @@ def do_ingest(destructive: bool = False) -> ResultEnvelope:
             current_files.add(fr.relative_path)
             # gating: raw bytes
             if not should_ingest_changed_file(fr, cfg):
-                m = f"Skipping {fr.relative_path}: file already ingested and unchanged"
+                m = f"Skipping {
+                    fr.relative_path}: file already ingested and unchanged"
                 logger.warning(m)
                 ingest_result.warnings.append(ResultMessage(
                     code="unchanged", message=m))
@@ -97,6 +98,11 @@ def do_ingest(destructive: bool = False) -> ResultEnvelope:
                     filename=Path(fr.path).name,
                 )
                 result = parser_service.parse_document(inp)
+                for w in result.warnings:
+                    logger.warning(w)
+                    ingest_result.warnings.append(
+                        ResultMessage(code="encoding_warning", message=w)
+                    )
                 doc = result.document
                 # gating: parsed document
                 ok2, reason2 = should_ingest_parsed_document(doc)
@@ -131,6 +137,7 @@ def do_ingest(destructive: bool = False) -> ResultEnvelope:
                 chunk_rows = []
                 embedding_meta_rows = []
                 vectors = []
+                ts = datetime.now().isoformat(timespec='seconds')
                 for ch, em in zip(chunks, em_results):
                     chunk_rows.append(
                         {
@@ -144,7 +151,7 @@ def do_ingest(destructive: bool = False) -> ResultEnvelope:
                             "page_number": getattr(ch, "page_number", None),
                             "heading_path_json": getattr(ch, "heading_path_json", None),
                             "chunk_config_hash": ch.config_hash,
-                            "created_at": "",
+                            "created_at": ts,
                         }
                     )
                     embedding_meta_rows.append(
@@ -153,7 +160,7 @@ def do_ingest(destructive: bool = False) -> ResultEnvelope:
                             "embedding_model_id": cfg.embedding.model_id,
                             "dim": cfg.embedding.dim,
                             "normalized": 1 if cfg.embedding.normalize else 0,
-                            "created_at": "",
+                            "created_at": ts,
                         }
                     )
                     vectors.append((ch.chunk_id, em.vector.tolist()))

--- a/src/raggen/core/ingest/ingest_service.py
+++ b/src/raggen/core/ingest/ingest_service.py
@@ -98,6 +98,19 @@ def do_ingest(destructive: bool = False) -> ResultEnvelope:
                     filename=Path(fr.path).name,
                 )
                 result = parser_service.parse_document(inp)
+                if result.encoding_error_ratio > cfg.scan.max_encoding_error_ratio:
+                    m = (
+                        f"Skipping {fr.relative_path}: "
+                        f"{result.encoding_error_ratio:.1%} of content is invalid UTF-8 "
+                        f"(threshold: {cfg.scan.max_encoding_error_ratio:.1%}). "
+                        "File is likely binary or severely corrupted."
+                    )
+                    logger.warning(m)
+                    ingest_result.warnings.append(
+                        ResultMessage(code="binary_or_corrupt", message=m)
+                    )
+                    skip_count += 1
+                    continue
                 for w in result.warnings:
                     logger.warning(w)
                     ingest_result.warnings.append(

--- a/src/raggen/core/parsing/PlainTextParser.py
+++ b/src/raggen/core/parsing/PlainTextParser.py
@@ -26,7 +26,15 @@ class PlainTextFallbackParser:
         if not inp.data:
             raise ValueError("ParseInput.data is empty")
 
-        raw = inp.data.decode("utf-8", errors="replace")
+        warnings = []
+        try:
+            raw = inp.data.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            raw = inp.data.decode("utf-8", errors="replace")
+            warnings.append(
+                f"{inp.doc_id}: file contains invalid UTF-8 bytes; "
+                "replacement characters were inserted."
+            )
 
         raw = _normalize_line_endings(raw)
         paragraphs = _split_paragraphs_drop_empty(raw)
@@ -53,4 +61,5 @@ class PlainTextFallbackParser:
             document=doc,
             parser_id=self.parser_id,
             effective_mimetype=effective,
+            warnings=warnings,
         )

--- a/src/raggen/core/parsing/PlainTextParser.py
+++ b/src/raggen/core/parsing/PlainTextParser.py
@@ -27,13 +27,17 @@ class PlainTextFallbackParser:
             raise ValueError("ParseInput.data is empty")
 
         warnings = []
+        encoding_error_ratio = 0.0
         try:
             raw = inp.data.decode("utf-8", errors="strict")
         except UnicodeDecodeError:
             raw = inp.data.decode("utf-8", errors="replace")
+            replacement_count = raw.count("\ufffd")
+            encoding_error_ratio = replacement_count / max(len(raw), 1)
             warnings.append(
-                f"{inp.doc_id}: file contains invalid UTF-8 bytes; "
-                "replacement characters were inserted."
+                f"{inp.doc_id}: file contains invalid UTF-8 bytes "
+                f"({replacement_count} replacement characters, "
+                f"{encoding_error_ratio:.1%} of content)."
             )
 
         raw = _normalize_line_endings(raw)
@@ -62,4 +66,5 @@ class PlainTextFallbackParser:
             parser_id=self.parser_id,
             effective_mimetype=effective,
             warnings=warnings,
+            encoding_error_ratio=encoding_error_ratio,
         )

--- a/src/raggen/core/parsing/parser.py
+++ b/src/raggen/core/parsing/parser.py
@@ -33,6 +33,7 @@ class ParseResult(BaseModel):
     parser_id: str  # e.g. "docx:v1", "plaintext:v1"
     effective_mimetype: str  # after normalization/fallback selection
     warnings: list[str] = []
+    encoding_error_ratio: float = 0.0
 
 
 class Parser(Protocol):

--- a/src/raggen/core/parsing/parser.py
+++ b/src/raggen/core/parsing/parser.py
@@ -32,6 +32,7 @@ class ParseResult(BaseModel):
     document: Document
     parser_id: str  # e.g. "docx:v1", "plaintext:v1"
     effective_mimetype: str  # after normalization/fallback selection
+    warnings: list[str] = []
 
 
 class Parser(Protocol):

--- a/src/raggen/core/query/service.py
+++ b/src/raggen/core/query/service.py
@@ -63,7 +63,7 @@ def query(request: QueryRequest) -> ResultEnvelope:
     )
 
     if not search_results:
-        response
+        return query_result
 
     chunk_ids = [chunk_id for chunk_id, _score in search_results]
     score_by_chunk_id = {chunk_id: score for chunk_id, score in search_results}

--- a/src/raggen/core/store/initializer.py
+++ b/src/raggen/core/store/initializer.py
@@ -55,7 +55,6 @@ def validate_existing_project(engine: Engine, cfg: ProjectConfig) -> None:
     except Exception:
         # Table may not exist yet; treat as no stored project
         res = None
-    print(f"RESULT FROM STORED PROJECT:\n{res}")
     conn.close()
     if not res:
         return
@@ -63,7 +62,8 @@ def validate_existing_project(engine: Engine, cfg: ProjectConfig) -> None:
 
     if diffs:
         raise SchemaMismatchError(
-            f"Stored project configuration differs: {json.dumps(diffs, indent=2)}\nRun with destructive=True to reinitialize."
+            f"Stored project configuration differs: {json.dumps(
+                diffs, indent=2)}\nRun with destructive=True to reinitialize."
         )
 
 
@@ -106,7 +106,8 @@ def init_database(cfg: ProjectConfig, *, destructive: bool = False) -> Engine:
 
     if not backend.supports(engine):
         raise BackendNotSupportedError(
-            f"Backend '{backend.key}' does not support engine dialect '{engine.dialect.name}'"
+            f"Backend '{backend.key}' does not support engine dialect '{
+                engine.dialect.name}'"
         )
 
     existing = _fetch_project_row(engine)

--- a/tests/test_ingest_gating.py
+++ b/tests/test_ingest_gating.py
@@ -97,7 +97,7 @@ def test_empty_parsed_document_is_skipped(tmp_path, monkeypatch):
     # Make parser return an empty-text document
     def _empty_parse(self, inp):
         doc = SimpleNamespace(doc_id=inp.doc_id, text="", source=inp.doc_id)
-        return SimpleNamespace(document=doc)
+        return SimpleNamespace(document=doc, warnings=[])
     monkeypatch.setattr(ParserService, "parse_document", _empty_parse)
 
     # Ensure chunker is NOT called
@@ -147,7 +147,7 @@ def test_whitespace_only_file_is_skipped(tmp_path, monkeypatch):
     def _ws_parse(self, inp):
         doc = SimpleNamespace(
             doc_id=inp.doc_id, text="   \n  ", source=inp.doc_id)
-        return SimpleNamespace(document=doc)
+        return SimpleNamespace(document=doc, warnings=[])
     monkeypatch.setattr(ParserService, "parse_document", _ws_parse)
 
     chunker = ChunkerRegistry().get("fallback")

--- a/tests/test_ingest_gating.py
+++ b/tests/test_ingest_gating.py
@@ -97,7 +97,7 @@ def test_empty_parsed_document_is_skipped(tmp_path, monkeypatch):
     # Make parser return an empty-text document
     def _empty_parse(self, inp):
         doc = SimpleNamespace(doc_id=inp.doc_id, text="", source=inp.doc_id)
-        return SimpleNamespace(document=doc, warnings=[])
+        return SimpleNamespace(document=doc, warnings=[], encoding_error_ratio=0.0)
     monkeypatch.setattr(ParserService, "parse_document", _empty_parse)
 
     # Ensure chunker is NOT called
@@ -147,7 +147,7 @@ def test_whitespace_only_file_is_skipped(tmp_path, monkeypatch):
     def _ws_parse(self, inp):
         doc = SimpleNamespace(
             doc_id=inp.doc_id, text="   \n  ", source=inp.doc_id)
-        return SimpleNamespace(document=doc, warnings=[])
+        return SimpleNamespace(document=doc, warnings=[], encoding_error_ratio=0.0)
     monkeypatch.setattr(ParserService, "parse_document", _ws_parse)
 
     chunker = ChunkerRegistry().get("fallback")


### PR DESCRIPTION
Expose an option for encoding issues. Giving a way to skip binary or corrupted files.
Still assumes utf-8 encoding.